### PR TITLE
Update GravTrapObjectsType.cs

### DIFF
--- a/GravTrapImproved/src/GravTrapObjectsType.cs
+++ b/GravTrapImproved/src/GravTrapObjectsType.cs
@@ -121,8 +121,12 @@ namespace GravTrapImproved
 
 			if (obj.GetComponent<GasPod>() is GasPod gasPod)
 				return gasPod.detonated? TechType.None: TechType.GasPod;
+
+			if (obj.GetComponent<Pickupable>() is Pickupable P && P.overrideTechUsed && P.overrideTechType != TechType.None)
+				return P.overrideTechType;
+
 #endif
-			return CraftData.GetTechType(obj);
+				return CraftData.GetTechType(obj);
 		}
 
 		public bool isValidTarget(GameObject obj) // ! called on each frame for each attracted object


### PR DESCRIPTION
Modified the getObjectTechType() method to check for a Pickupable on the target item, and use its overrideTechType if appropriate; this allows the GravTrap to pick up, for example, broken pieces of table coral in Subnautica 1. (assuming the JeweledDiskPiece TechType is added to the config as a grabbable item)